### PR TITLE
add function to handle single struct

### DIFF
--- a/lib/caramelizer.ex
+++ b/lib/caramelizer.ex
@@ -94,6 +94,13 @@ defmodule Caramelize do
     date_time
   end
 
+  # if a struct, convert to map and then camelize
+  def camelize(%{__struct__: _} = map) do
+    map
+    |> Map.from_struct
+    |> camelize
+  end
+
   # base camelize function
   def camelize(%{} = map) do
     map

--- a/test/caramelizer_test.exs
+++ b/test/caramelizer_test.exs
@@ -20,6 +20,12 @@ defmodule CaramelizeTest do
                                                   "testBaz" => "baz"}]
     end
 
+    test "works with a struct" do
+      assert Caramelize.camelize(%__MODULE__{}) == %{"testFoo" => "foo",
+                                                  "testBar" => "bar",
+                                                  "testBaz" => "baz"}
+    end
+
     test "works with a list of primitives" do
       primitives = [1, "foo", 4.3, :cool_atom]
       assert Caramelize.camelize(primitives) == primitives


### PR DESCRIPTION
 @hammeraj and I discovered that the caramelizer wasn't camelizing keys when passing a single struct. Structs being bare maps do not implement the enumerable protocols

- Added a function and test for the same
- Tested the branch with our current working branch and it worked