### PR TITLE
remove dependency on ecto

### DIFF
--- a/lib/caramelizer.ex
+++ b/lib/caramelizer.ex
@@ -82,22 +82,8 @@ defmodule Caramelize do
     {key, value}
   end
 
-  # if a NaiveDateTime struct, just pass it along and
-  # let phoenix handle the serialization
-  def camelize(%NaiveDateTime{} = date_time) do
-    date_time
-  end
-
-  # if a DateTime struct, just pass it along and
-  # let phoenix handle the serialization
-  def camelize(%DateTime{} = date_time) do
-    date_time
-  end
-
-  # if a DateTime struct, just pass it along and
-  # let phoenix handle the serialization
-  def camelize(%Ecto.DateTime{} = date_time) do
-    date_time
+  def camelize(%struct{} = datetime) when struct in [DateTime, Ecto.DateTime, NaiveDateTime] do
+    datetime
   end
 
   # if a struct, convert to map and then camelize

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule Caramelize.Mixfile do
 
   def project do
     [app: :caramelize,
-     version: "0.1.3",
-     elixir: "~> 1.7.3",
+     version: "0.2.0",
+     elixir: "~> 1.7",
      description: description(),
      package: package(),
      build_embedded: Mix.env == :prod,
@@ -21,7 +21,7 @@ defmodule Caramelize.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :ecto]]
+    [applications: [:logger]]
   end
 
   defp description do
@@ -32,8 +32,7 @@ defmodule Caramelize.Mixfile do
 
   defp deps do
     [{:ex_doc, ">= 0.0.0", only: :dev},
-     {:credo, "~> 0.4", only: [:dev, :test]},
-     {:ecto, "~> 2.2.7"}]
+     {:credo, "~> 0.4", only: [:dev, :test]}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,10 @@
 %{
-  "bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.4.12", "f5e1973405ea25c6e64959fb0b6bf92950147a0278cc2a002a491b45f78f7b87", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
-  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ecto": {:hex, :ecto, "2.2.10", "e7366dc82f48f8dd78fcbf3ab50985ceeb11cb3dc93435147c6e13f2cda0992e", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.10.2", "03ad3a1eff79a16664ed42fc2975b5e5d0ce243d69318060c626c34720a49512", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
 }

--- a/test/caramelizer_test.exs
+++ b/test/caramelizer_test.exs
@@ -7,10 +7,8 @@ defmodule CaramelizeTest do
     test_baz: "baz"
 
   describe "camelize/1" do
-
-
     test "works with an Ecto.DateTime struct" do
-      {:ok, now} = Ecto.DateTime.cast("2016-05-21 12:12:12")
+      now = %{__struct__: Ecto.DateTime, right_now: "right now!"}
       assert Caramelize.camelize(now) == now
     end
 
@@ -31,5 +29,4 @@ defmodule CaramelizeTest do
       assert Caramelize.camelize(primitives) == primitives
     end
   end
-
 end


### PR DESCRIPTION
There is currently a dependency on Ecto, and it's really just for pattern matching on the Ecto.DateTime struct. This removes the dependency and updates all the others.