### PR TITLE
Revert caramelize changes due to bug in recase

### DIFF
--- a/lib/caramelize.ex
+++ b/lib/caramelize.ex
@@ -54,7 +54,9 @@ defmodule Caramelize do
 
   # Camelize strings in a map
   def camelize(key) when is_binary(key) do
-    Recase.to_camel(key)
+    capitalized = Macro.camelize(key)
+    <<first>> <> rest = capitalized
+    String.downcase(<<first>>) <> rest
   end
 
   # if a nested map, camelize the nested map keys

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Caramelize.Mixfile do
   def project do
     [
       app: :caramelize,
-      version: "1.2.0",
+      version: "1.2.1",
       elixir: "~> 1.7",
       description: description(),
       package: package(),


### PR DESCRIPTION
Recase has a bug where if something is already in camel case, to_camel tends to mess it up. This will revert the caramelize changes while keeping snekize.